### PR TITLE
User sad path

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,10 +2,15 @@ class Api::V1::UsersController < Api::V1::BaseController
 
   def create
       user = User.create(user_params)
-      token = JsonWebToken.encode({user_id: user.id})
-      key_params = {params: {api_key: token}}
-      response.status = :created
-      render json: UserSerializer.new(user, key_params ).serialized_json
+      if user.valid?
+        token = JsonWebToken.encode({user_id: user.id})
+        key_params = {params: {api_key: token}}
+        response.status = :created
+        render json: UserSerializer.new(user, key_params ).serialized_json
+      else
+        response.status = :bad_request
+        render json: {errors: user.errors.full_messages.to_sentence}.to_json
+      end
   end
 
   private

--- a/spec/requests/api/v1/user_spec.rb
+++ b/spec/requests/api/v1/user_spec.rb
@@ -23,4 +23,48 @@ RSpec.describe "when a client makes a request to /user" do
 
   end
 
+  it "With invalid params the response is 4XX and relevent error message" do
+    user_params =
+    {
+      "email": "whatever@example.com",
+      "password": "password",
+      "password_confirmation": "NotTheSamepassword"
+    }
+    post '/api/v1/users', params: user_params
+    response_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.status).to eq(400)
+    expect(response_json[:errors]).to eq("Password confirmation doesn't match Password")
+  end
+
+  it "Cannot register duplicate emails" do
+    User.create!(email: "whatever@example.com", password: "password", password_confirmation: "password")
+    user_params =
+    {
+      "email": "whatever@example.com",
+      "password": "password",
+      "password_confirmation": "password"
+    }
+    post '/api/v1/users', params: user_params
+    response_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.status).to eq(400)
+    expect(response_json[:errors]).to eq("Email has already been taken")
+  end
+
+  it "Response with multiple errors" do
+    User.create!(email: "whatever@example.com", password: "password", password_confirmation: "password")
+    user_params =
+    {
+      "email": "whatever@example.com",
+      "password": "password",
+      "password_confirmation": "NotTheSamepassword"
+    }
+    post '/api/v1/users', params: user_params
+    response_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.status).to eq(400)
+    expect(response_json[:errors]).to eq("Email has already been taken and Password confirmation doesn't match Password")
+  end
+
 end


### PR DESCRIPTION
# User post request sad paths
Resolves: #17 
## Client now gets error messages and status 400 when attempting to create a new user with invalid credentials
### Added
 - Sad path tests to user request test file
 - Controller logic to add error messages to response when user is invalid