### PR TITLE
Longer Hourly Forecast

### DIFF
--- a/app/poros/forecast.rb
+++ b/app/poros/forecast.rb
@@ -12,7 +12,7 @@ class Forecast
   private
 
   def parse_hourly(hourly_data)
-    12.times do |i|
+    24.times do |i|
       @hourly << HourlyConditions.new(hourly_data[i])
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,4 +75,5 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.filter_sensitive_data('<GOOGLE_KEY>') {ENV['GOOGLE_KEY']}
   config.filter_sensitive_data('<OPEN_WEATHER_KEY>') {ENV['OPEN_WEATHER_KEY']}
+  config.default_cassette_options = { allow_playback_repeats: true } 
 end


### PR DESCRIPTION
# Save 24 Hours of Forecast Data
### Forecast Poro now save 24 hours of hourly forecast data for longer road trip.
#### Modified
- forecast.rb